### PR TITLE
fix crash and invalid trace on test failures

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -156,14 +156,14 @@ int init(void)
 	exit(1);
     }
 
-    if (ne_uri_parse(test_argv[optind], &u)) {
+    if (ne_uri_parse(test_argv[optind], &u) || !u.host || !u.path) {
 	t_context("couldn't parse server URL `%s'",
 		  test_argv[optind]);
 	return FAILHARD;
     }       
 
     if (proxy_url) {
-	if (ne_uri_parse(proxy_url, &proxy)) {
+	if (ne_uri_parse(proxy_url, &proxy) || !proxy.host) {
 	    t_context("couldn't parse proxy URL `%s'", proxy_url);
 	    return FAILHARD;
 	}

--- a/src/locks.c
+++ b/src/locks.c
@@ -83,7 +83,7 @@ static int getlock(enum ne_lock_scope scope, int depth)
     ONMREQ("LOCK", res, ne_lock(i_session, &reslock));
     
     if (scope != reslock.scope) {
-        t_context("requested lockscope not satisfied!  got %s, wanted %s",
+        t_context("requested lockscope not satisfied!  wanted %s, got %s",
                   scope == ne_lockscope_exclusive ? "exclusive" : "shared",
                   reslock.scope == ne_lockscope_exclusive ? 
                   "exclusive" : "shared");


### PR DESCRIPTION
fix crash and invalid trace on test failures

These are a couple commits from 2016 for issues I ran into with litmus when I was bringing [lighttpd mod_webdav](https://wiki.lighttpd.net/mod_webdav) up to RFC4918.  I do not have immediate example of the items they fix, but the changes are only a few lines and the commit messages describe the issues they fix.

If there are questions, please ask and I'll add more details.