### PR TITLE
modify put_location for optional Location

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,7 @@
 Changes in version 0.15:
 * New tests:
  - props: test for DAV:getlastmodified property value
- - basic: test for Location header returned by PUT
+ - basic: test Location header if returned by PUT
 * Bug fixes:
  - fix crash on invalid URL command-line (Glenn Strauss)
  - locks: fixed lockscope check error reporting (Glenn Strauss)

--- a/src/basic.c
+++ b/src/basic.c
@@ -244,6 +244,7 @@ static int put_location(void)
     ONV(ne_get_status(req)->code != 201,
         ("PUT to create resource MUST return 201 [RFC9110ẞ9.3.4]"));
 
+    /* PUT to create resource might return Location with 201 [RFC9110ẞ15.3.2] */
     s = ne_get_response_header(req, "Location");
     if (s) {
         ne_uri uri = {0};
@@ -255,9 +256,6 @@ static int put_location(void)
             ("Location header was %s not %s", s, PUT_HASH));
 
         ne_uri_free(&uri);
-    }
-    else {
-        t_warning("PUT for new resource did not include a Location header");
     }
 
     ne_request_destroy(req);


### PR DESCRIPTION
do not issue warning if Location is not provided with 201 Created

As posted in https://github.com/notroj/litmus/pull/14#issuecomment-1948010917:

RFC9110
> [15.3.2. ](https://www.rfc-editor.org/rfc/rfc9110#section-15.3.2)[201 Created](https://www.rfc-editor.org/rfc/rfc9110#name-201-created)
> 
> The 201 (Created) status code indicates that the request has been fulfilled and has resulted in one or more new resources being created. The primary resource created by the request is identified by either a [Location](https://www.rfc-editor.org/rfc/rfc9110#field.location) header field in the response or, if no [Location](https://www.rfc-editor.org/rfc/rfc9110#field.location) header field is received, by the target URI.

As per above, Location is optional when returning 201 Created for PUT request which can be retrieved at the same target URI.