### PR TITLE
Option handling improvements, TLS trust default update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ basic
 /config.guess
 /config.sub
 /ltmain.sh
+/largefile

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+Changes in version 0.17:
+* Default TLS SSL CAs are trusted by default; new --insecure/-i
+  option to ignore verification failures for untrusted TLS certs.
+* Update to neon 0.34.2.
+
 Changes in version 0.16:
 * New tests:
  - props: test that deleting a property twice succeeds

--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ or
  $ litmus http://dav.example.com/path/ jim 2518
 ~~~
 
+## SSL/TLS
+
+Since version 0.17 `litmus` trusts the default TLS CA certificates
+configured in the SSL library. If you want to run against a server
+with a self-signed or otherwise untrusted server certificate, use the
+--insecure option, e.g.
+
+~~~
+ $ litmus --insecure https://dav.example.com/path/
+~~~
+
+`litmus` can use a TLS client certificate, which must be provided in
+PKCS#12 format. e.g.:
+
+~~~
+ $ litmus --client-cert=client.p12 https://dav.example.com/path/
+~~~
+
 ## Copyright and licensing
 
 litmus is licensed under the GNU GPL; see COPYING for full details.

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 dnl autoconf script for litmus
 
-AC_INIT([litmus],[0.15],[],[],[https://github.com/notroj/litmus])
+AC_INIT([litmus],[0.17],[],[],[https://github.com/notroj/litmus])
 
 AC_PREREQ([2.59])
 
@@ -38,7 +38,9 @@ NEON_FORMAT(long long)
 NEON_DEBUG
 NEON_WARNINGS
 
-CPPFLAGS="$CPPFLAGS -I\${top_builddir}"
+# Define NEON_TEST_INIT so that litmus_init() is used as test
+# framework initializer in all builds.
+CPPFLAGS="$CPPFLAGS -I\${top_builddir} -DNEON_TEST_INIT=litmus_init"
 
 AC_CONFIG_FILES([litmus], [chmod +x litmus])
 AC_CONFIG_FILES([Makefile neon/src/Makefile])

--- a/litmus.in
+++ b/litmus.in
@@ -18,6 +18,7 @@ Options:
  -k, --keep-going        continue testing even if one suite fails
  -p, --proxy=URL         use given proxy server URL
  -c, --client-cert=CERT  use given PKCS#12 client cert
+ -i, --insecure          ignore TLS certificate verification failures
 
 Significant environment variables:
 

--- a/litmus.in
+++ b/litmus.in
@@ -17,9 +17,13 @@ litmus: Usage: $0 [OPTIONS] URL [USERNAME PASSWORD]
 Options:
  -k, --keep-going        continue testing even if one suite fails
  -p, --proxy=URL         use given proxy server URL
+ -s, --system-proxy      use proxy server configuration from system
  -c, --client-cert=CERT  use given PKCS#12 client cert
  -i, --insecure          ignore TLS certificate verification failures
-
+ -q, --quiet             use abbreviated output
+ -n, --no-colour         enable coloured output
+ -o, --colour            disable coloured output
+ 
 Significant environment variables:
 
     \$TESTS     - specify test programs to run

--- a/src/common.c
+++ b/src/common.c
@@ -123,7 +123,7 @@ static int test_resolve(const char *hostname, const char *name)
     return OK;
 }
 
-int init(void)
+int litmus_init(int argc, const char *const *argv, int *use_colour, int *quiet)
 {
     ne_uri u = {0}, proxy = {0};
     int optc, n;

--- a/src/common.c
+++ b/src/common.c
@@ -131,32 +131,35 @@ int litmus_init(int argc, const char *const *argv, int *use_colour, int *quiet)
     char *proxy_url = NULL;
 
     while ((optc = getopt_long(test_argc, test_argv, 
-			       "c:d:hip:qno", longopts, NULL)) != -1) {
+			       "c:d:hinop:qs", longopts, NULL)) != -1) {
 	switch (optc) {
+        case 'c':
+            client_certificate = optarg;
+            break;
 	case 'd':
             t_warning("the 'htdocs' argument is now ignored");
-	    break;
-	case 'p':
-	    proxy_url = optarg;
-	    break;
-	case 's':
-	    system_proxy = 1;
 	    break;
 	case 'h':
 	    usage(stdout);
 	    exit(1);
-        case 'c':
-            client_certificate = optarg;
+        case 'i':
+            tls_trust_everything = 1;
             break;
         case 'n':
             *use_colour = 0;
             break;
+        case 'o':
+            *use_colour = 1;
+            break;
+	case 'p':
+	    proxy_url = optarg;
+	    break;
         case 'q':
             *quiet = 1;
             break;
-        case 'i':
-            tls_trust_everything = 1;
-            break;
+	case 's':
+	    system_proxy = 1;
+	    break;
 	default:
 	    usage(stderr);
 	    exit(1);

--- a/src/common.h
+++ b/src/common.h
@@ -47,7 +47,7 @@ TF(init); TF(begin);
 TF(options); TF(finish);
 
 /* Standard initialisers for tests[] array: start everything up: */
-#define INIT_TESTS T(init), T(begin)
+#define INIT_TESTS T(begin)
 
 /* And finish everything off */
 #define FINISH_TESTS T(finish), T(NULL)


### PR DESCRIPTION
```
Switch to trust default TLS CAs by default, require -i option for
untrusted server certificates.

* src/common.c (init): Support -i / --insecure option. Fail here if an https: URL is used and neon doesn't support TLS. (init_session): Trust default CAs by default. Install callback to trust all server certs only if --insecure is used. Don't verify neon TLS support status here.

* litmus.in (usage): Document -i / --insecure.
```