### PR TITLE
Simplify and avoid direct-connection test by default

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 Changes in version 0.17:
 * Default TLS SSL CAs are trusted by default; new --insecure/-i
   option to ignore verification failures for untrusted TLS certs.
+* New options --colour, --no-colour, --quiet, --system-proxy,
+  --client-cert-uri, --insecure
 * Update to neon 0.34.2.
 
 Changes in version 0.16:

--- a/litmus.in
+++ b/litmus.in
@@ -15,14 +15,15 @@ usage() {
 litmus: Usage: $0 [OPTIONS] URL [USERNAME PASSWORD]
 
 Options:
- -k, --keep-going        continue testing even if one suite fails
- -p, --proxy=URL         use given proxy server URL
- -s, --system-proxy      use proxy server configuration from system
- -c, --client-cert=CERT  use given PKCS#12 client cert
- -i, --insecure          ignore TLS certificate verification failures
- -q, --quiet             use abbreviated output
- -n, --no-colour         enable coloured output
- -o, --colour            disable coloured output
+ -k, --keep-going           continue testing even if one suite fails
+ -p, --proxy=URL            use given proxy server URL
+ -s, --system-proxy         use proxy server configuration from system
+ -c, --client-cert=CERT     use given PKCS#12 client cert
+ -u, --client-cert-uri=URI  use given client cert URI
+ -i, --insecure             ignore TLS certificate verification failures
+ -q, --quiet                use abbreviated output
+ -n, --no-colour            enable colour in output
+ -o, --colour               disable colour in output
  
 Significant environment variables:
 

--- a/src/basic.c
+++ b/src/basic.c
@@ -211,10 +211,10 @@ static int put_location(void)
     ONNREQ("PUT failed", ne_request_dispatch(req));
 
     ONV(ne_get_status(req)->code != 201,
-        ("PUT to create '%s' MUST return 201 (got %d) [RFC9110ẞ9.3.4]",
+        ("PUT to create '%s' MUST return 201 (got %d) [RFC9110:S9.3.4]",
          put_uri, ne_get_status(req)->code));
 
-    /* PUT to create resource might return Location with 201 [RFC9110ẞ15.3.2] */
+    /* PUT to create resource might return Location with 201 [RFC9110:S15.3.2] */
     s = ne_get_response_header(req, "Location");
     if (s) {
         ne_uri uri = {0};

--- a/src/common.c
+++ b/src/common.c
@@ -75,14 +75,21 @@ static const struct option longopts[] = {
     { NULL }
 };
 
+#define HELPOPTS                                                        \
+" -p, --proxy=URL            use given proxy server URL\n"              \
+" -s, --system-proxy         use proxy server configuration from system\n" \
+" -c, --client-cert=CERT     use given PKCS#12 client cert\n"           \
+" -u, --client-cert-uri=URI  use given client cert URI\n"               \
+" -i, --insecure             ignore TLS certificate verification failures\n" \
+" -q, --quiet                use abbreviated output\n"                  \
+" -n, --no-colour            enable colour in output\n"                 \
+" -o, --colour               disable colour in output\n"
+
 static void usage(FILE *output)
 {
     fprintf(output, 
 	    "\rUsage: %s [OPTIONS] URL [username password]\n"
-	    " Options are:\n"
-	    "    -d PROXY  use PROXY as proxy URL\n"
-            "    -c CERT   use a PKCS#12 client certificate\n",
-	    test_argv[0]);
+	    "Options are:\n" HELPOPTS, test_argv[0]);
 }
 
 static int test_connect(void)

--- a/src/common.h
+++ b/src/common.h
@@ -37,13 +37,12 @@
 
 /* Standard test functions.
  * init: parses and verifies cmd-line args (URL, username/password)
- * test_connect: checks that server is running.
- * open_foo: opens the dummy 'foo' file.
+ * direct_connect: tests direct connection (optional, not recommended)
  * begin: opens session 'i_session' to server.
  * options: does an OPTIONS request on i_path, sets i_class2.
  * finish: closes i_session. */
 
-TF(init); TF(begin);
+TF(init); TF(begin); TF(direct_connect);
 TF(options); TF(finish);
 
 /* Standard initialisers for tests[] array: start everything up: */
@@ -56,10 +55,13 @@ TF(options); TF(finish);
 extern ne_session *i_session, *i_session2;
 
 /* server details. */
-extern const char *i_hostname;
-extern unsigned int i_port;
+extern ne_uri i_origin;
+#define i_path (i_origin.path)
+#define i_port (i_origin.port)
+#define i_hostname (i_origin.host)
+
+/* If test_direct_connect() is invoked, this will be non-NULL. */
 extern ne_sock_addr *i_address;
-extern char *i_path;
 
 extern int i_class2; /* true if server is a class 2 DAV server. */
 

--- a/src/http.c
+++ b/src/http.c
@@ -97,6 +97,7 @@ static int expect100(void)
 
 ne_test tests[] = {
     INIT_TESTS,
+    T(direct_connect),
 
     T(expect100),
 


### PR DESCRIPTION
```
Simplify and avoid direct-connection test by default, which is a naive
duplicate of neon's internal host handling which misses e.g. scoped IPv6 address handling.

* src/common.c: Define global i_origin URI object. (direct_connect): New function. (litmus_init): Simplify URI handling to use i_origin, drop direct connection logic. (begin): Use i_origin.

* src/common.h: Define i_path, i_port, i_hostname in terms of i_origin. Declare direct_connect() test.

* src/http.c: Use direct_connect test.
```