### PR TITLE
fix pthread.h include broken by CodeRabbit auto-fixes

### DIFF
--- a/src/lockbomb.c
+++ b/src/lockbomb.c
@@ -29,7 +29,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
-#if defined(HAVE_PTHREADS) && (THREADS > 1)
+#if defined(HAVE_PTHREADS)
 #include <pthread.h>
 #endif
 


### PR DESCRIPTION
fix pthread.h include broken by CodeRabbit auto-fixes

litmus fails to compile due to failure to `#include <pthread.h`
```
gcc -DHAVE_CONFIG_H  -I/usr/include/libxml2 -DWITH_GZFILEOP -I. -DNEON_TEST_INIT=litmus_init -I./src -I./test-common -pthread -g -O2  -I./neon/src -c src/lockbomb.c -o src/lockbomb.o
src/lockbomb.c: In function ‘lockbomb’:
src/lockbomb.c:112:15: error: implicit declaration of function ‘pthread_create’ [-Wimplicit-function-declaration]
  112 |         ret = pthread_create(&args[n].thd, NULL, threadfn, &args[n]);
      |               ^~~~~~~~~~~~~~
src/lockbomb.c:122:15: error: implicit declaration of function ‘pthread_join’ [-Wimplicit-function-declaration]
  122 |         ret = pthread_join(args[n].thd, (void **)&retval);
      |               ^~~~~~~~~~~~
make: *** [Makefile:132: src/lockbomb.o] Error 1
```

Can you spot the problem of checking `(THREADS > 1)` before setting a default value `#ifndef THREADS` a few lines below?
`git annotate src/lockbomb.c`
```
828c311d        (coderabbitai[bot]      2026-06-02 14:01:32 +0000       32)#if defined(HAVE_PTHREADS) && (THREADS > 1)
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       33)#include <pthread.h>
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       34)#endif
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       35)
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       36)#include <ne_session.h>
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       37)#include <ne_basic.h>
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       38)#include <ne_uri.h>
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       39)#include <ne_locks.h>
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       40)
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       41)#include "common.h"
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       42)
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       43)#define ITERS 20000
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       44)#ifndef THREADS
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       45)#define THREADS (20)
82d56273        ( Joe Orton     2026-05-13 14:38:57 +0100       46)#endif
```

Unreviewed AI auto-fixes committed by AI, amiright? /s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted internal build configuration to improve compatibility with threading support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->